### PR TITLE
Feature: Support downloading hugo extended

### DIFF
--- a/bin/hugo-installer.ts
+++ b/bin/hugo-installer.ts
@@ -20,10 +20,15 @@ const argv: { [ param: string ]: any } = yargs
         type: 'string',
         default: 'bin/hugo'
     } )
+    .option( 'extended', {
+        describe: 'Download Hugo extended',
+        type: 'boolean',
+        default: false
+    } )
     .strict()
     .argv;
 
-// If the version does not have the format of a version number, it's an object path
+// If the version does not have the format of a version number, assume it's an object path
 if ( isNaN( parseFloat( argv.version ) ) ) {
     const packageJson: any = require( path.resolve( process.cwd(), 'package.json' ) );
     const packageJsonHugoVersion: string | null = objectPath.get( packageJson, argv.version, null );
@@ -35,7 +40,8 @@ if ( isNaN( parseFloat( argv.version ) ) ) {
 }
 
 // Run
-console.log( `Download hugo binary (version "${ argv.version }") into "${ argv.destination }" ...` );
+const versionString = `${ argv.version }${ argv.extended ? "_extended" : "" }`;
+console.log( `Download hugo binary (version "${ versionString }") into "${ argv.destination }" ...` );
 installHugo( argv.version, argv.destination )
     .then( () => {
         console.log( 'Success!' );
@@ -44,7 +50,7 @@ installHugo( argv.version, argv.destination )
     .catch( ( error: any ) => {
         console.error( 'Error!' );
         if ( error.toString().indexOf( '404' ) !== -1 ) {
-            console.error( `  -> It seems like the hugo version "${ argv.version }" does not exist.` );
+            console.error( `  -> It seems like the hugo version "${ versionString }" does not exist.` );
         }
         console.log( '' );
         console.dir( error );


### PR DESCRIPTION
This PR adds a new CLI argument, `--extended`, that downloads Hugo extended instead of the standard version.