### PR TITLE
feat(hugo-installer): Add ability to configure http and https proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Hugo version to be configured someplace else, e.g. in a `otherDependencies` obje
 
 <br>
 
-### Full list of CLI parameters
+### CLI parameters
 
 The following lists all available CLI parameters and their respective default values. Only the `--version` CLI parameter is required.
 
@@ -99,6 +99,8 @@ The following lists all available CLI parameters and their respective default va
 | `--downloadUrl [url]`  | Source base URL from where the Hugo binary will be fetched. By default,<br>GitHub will be used. When using a custom URL, make sure to replicate<br>GitHub release asset URLs and append a trailing slash to the custom URL.<br><br>→ Default value: `https://github.com/gohugoio/hugo/releases/download/` |
 | `--extended`           | Download the extended version of Hugo.<br><br>→ Default value: `false`                                                                                                                                                                                                                                    |
 | `--force`              | Force clean install of Hugo, ignoring already installed / cached binaries.<br><br>→ Default value: `false`                                                                                                                                                                                                |
+| `--httpProxy [url]`    | HTTP Proxy URL, used when downloading Hugo binaries. Useful when working behind corporate proxies. Can also be configured using the `HTTP_PROXY` environment variable, the CLI argument (if used) will take precedence.                                                                                   |
+| `--httpsProxy [url]`   | HTTPS Proxy URL, used when downloading Hugo binaries. Useful when working behind corporate proxies. Can also be configured using the `HTTPS_PROXY` environment variable, the CLI argument (if used) will take precedence.                                                                                 |
 | `--os [os]`            | Operating system that the binary should run on. It is recommended to<br>use auto-detect by not using this option. <br><br>→ Default value: Auto-configured on runtime using `os.platform()`                                                                                                               |
 | `--skipChecksumCheck`  | Skip checksum checks for downloaded binaries. It is recommended to<br>leave this option enabled. <br><br>→ Default value: `true`                                                                                                                                                                          |
 | `--skipHealthCheck`    | Skip health checks for downloaded binaries. It is recommended to leave<br>this option enabled. <br><br>→ Default value: `true`                                                                                                                                                                            |
@@ -109,6 +111,17 @@ You can always take a look at all available CLI parameters using the `--help` CL
 ```bash
 hugo-installer --help
 ```
+
+<br>
+
+### Environment variables
+
+The following lists all environment variables that can be used, all of them being optional.
+
+| Environment variable | Description                                                                                                                                                                                                       |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `HTTP_PROXY`         | HTTP Proxy URL, used when downloading Hugo binaries. Useful when working behind corporate proxies. Can also be configured using the `--httpProxy [url]` CLI argument which (if used) will also take precedence.   |
+| `HTTPS_PROXY`        | HTTPS Proxy URL, used when downloading Hugo binaries. Useful when working behind corporate proxies. Can also be configured using the `--httpsProxy [url]` CLI argument which (if used) will also take precedence. |
 
 <br><br><br>
 

--- a/bin/hugo-installer.ts
+++ b/bin/hugo-installer.ts
@@ -45,6 +45,18 @@ const argv = yargs(hideBin(process.argv))
     describe: 'Force clean install of Hugo, ignoring already installed / cached binaries.',
     type: 'boolean',
   })
+  .option('httpProxy', {
+    default: process.env.HTTP_PROXY || null,
+    describe:
+      'HTTP Proxy URL, used when downloading Hugo binaries. Useful when working behind corporate proxies. Can also be configured using the "HTTP_PROXY" environment variable, the CLI argument (if used) will take precedence.',
+    type: 'string',
+  })
+  .option('httpsProxy', {
+    default: process.env.HTTPS_PROXY || null,
+    describe:
+      'HTTPS Proxy URL, used when downloading Hugo binaries. Useful when working behind corporate proxies. Can also be configured using the "HTTPS_PROXY" environment variable, the CLI argument (if used) will take precedence.',
+    type: 'string',
+  })
   .option('os', {
     choices: ['darwin', 'freebsd', 'linux', 'openbsd', 'win32'],
     default: os.platform(),
@@ -113,10 +125,12 @@ const bin = async (options: InstallHugoOptions): Promise<void> => {
 // Run
 bin({
   arch: argv.arch,
-  downloadUrl: argv.downloadUrl,
   destination: argv.destination,
+  downloadUrl: argv.downloadUrl,
   extended: argv.extended,
   force: argv.force,
+  httpProxy: argv.httpProxy,
+  httpsProxy: argv.httpsProxy,
   os: argv.os,
   skipChecksumCheck: argv.skipChecksumCheck,
   skipHealthCheck: argv.skipHealthCheck,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1654,6 +1654,11 @@
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
+    "hpagent": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-0.1.2.tgz",
+      "integrity": "sha512-ePqFXHtSQWAFXYmj+JtOTHr84iNrII4/QRlAAPPE+zqnKy4xJo7Ie1Y4kC7AdB+LxLxSTTzBMASsEcy0q8YyvQ=="
+    },
     "http-cache-semantics": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "decompress": "4.2.x",
     "del": "6.0.x",
     "got": "11.8.x",
+    "hpagent": "0.1.x",
     "object-path": "0.11.x",
     "semver": "7.3.x",
     "yargs": "16.2.x"

--- a/src/install-hugo.interfaces.ts
+++ b/src/install-hugo.interfaces.ts
@@ -7,6 +7,8 @@ export interface InstallHugoOptions {
   downloadUrl: string;
   extended: boolean;
   force: boolean;
+  httpProxy: string | null;
+  httpsProxy: string | null;
   os: string;
   skipChecksumCheck: boolean;
   skipHealthCheck: boolean;


### PR DESCRIPTION
- Add `httpProxy` and `httpsProxy` CLI arguments
- Use `HTTP_PROXY` and `HTTPS_PROXY` environment variable values (CLI arguments take precedence)
- Fetch using proxy values (if defined)
- Update docs

Tested manually on my locale Windows machine using [Fiddler](https://www.telerik.com/fiddler), in particular using the Fiddler URL as a proxy. Configuring an https proxy, for instance, routes requests to GitHub (https) through Fiddler. Screenshot:

![image](https://user-images.githubusercontent.com/7271961/126785490-3b5f8a3e-6ed5-4018-b035-bca8c9ed20c1.png)