### PR TITLE
Bump GitHub workflow actions to their latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,14 +9,14 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup NodeJS
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: 14.20.x
+          node-version: 14.21.x
       - name: Install dependencies
         run: npm ci
       - name: Build
@@ -25,14 +25,14 @@ jobs:
   lint:
     name: Lint
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup NodeJS
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: 14.20.x
+          node-version: 14.21.x
       - name: Install dependencies
         run: npm ci
       - name: Lint
@@ -46,14 +46,14 @@ jobs:
       fail-fast: false
       matrix:
         # See <https://nodejs.org/en/about/releases/>
-        node-version: [14.20.0, 16.17.0, 18.9.0]
+        node-version: [16.20.2, 18.19.0, 20.10.0]
         # See <https://github.com/actions/runner-images#available-images>
         os: [ubuntu-22.04, windows-2022, macos-12]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup NodeJS ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,14 +7,14 @@ on:
 jobs:
   publish-to-npm:
     name: Publish to npm
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup NodeJS
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: 14.20.x
+          node-version: 14.21.x
           registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies
         run: npm ci

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The Hugo version can be set using the `--version` CLI parameter. For example:
 ```json
 {
   "scripts": {
-    "postinstall": "hugo-installer --version 0.103.0"
+    "postinstall": "hugo-installer --version 0.121.1"
   }
 }
 ```
@@ -67,7 +67,7 @@ You can also use the extended version of Hugo (for some operating systems!) by s
 ```json
 {
   "scripts": {
-    "postinstall": "hugo-installer --version 0.103.0 --extended"
+    "postinstall": "hugo-installer --version 0.121.1 --extended"
   }
 }
 ```
@@ -78,7 +78,7 @@ Hugo version to be configured someplace else, e.g. in a `otherDependencies` obje
 ```json
 {
   "otherDependencies": {
-    "hugo": "0.103.0"
+    "hugo": "0.121.1"
   },
   "scripts": {
     "postinstall": "hugo-installer --version otherDependencies.hugo"

--- a/src/install-hugo.ts
+++ b/src/install-hugo.ts
@@ -102,7 +102,7 @@ const fetchBinary = async ({
     const binaryResponse = await got(binaryUrl, createFetchOptions({ httpProxy, httpsProxy }));
     binaryAsBuffer = binaryResponse.rawBody;
   } catch (error) {
-    throw new Error(`An error occured while trying to download the binary from "${binaryUrl}". Details: ${error.message}`);
+    throw new Error(`An error occurred while trying to download the binary from "${binaryUrl}". Details: ${error.message}`);
   }
 
   // Done
@@ -156,7 +156,7 @@ const verifyBinaryChecksum = async (
     const checksumResponse = await got(checksumUrl, createFetchOptions({ httpProxy, httpsProxy }));
     rawChecksums = checksumResponse.body;
   } catch (error) {
-    throw new Error(`An error occured while trying to download the checksum. Details: ${error.message}`);
+    throw new Error(`An error occurred while trying to download the checksum. Details: ${error.message}`);
   }
 
   // Find expected checksum
@@ -165,7 +165,7 @@ const verifyBinaryChecksum = async (
       return rawChecksumLine.endsWith(binaryFileName);
     }) || null;
   if (rawChecksumLine === null) {
-    throw new Error(`An error occured while trying to find the checksum for version "${version}" the checksum.`);
+    throw new Error(`An error occurred while trying to find the checksum for version "${version}" the checksum.`);
   }
   const expectedChecksum = rawChecksumLine.split(' ')[0];
 
@@ -213,7 +213,7 @@ const verifyBinaryHealth = async ({ destination }: Pick<InstallHugoOptions, 'des
       resolve(hugoVersionConsoleOutput);
     });
     childProcess.on('error', (error) => {
-      reject(`An error occured while verifiy the binary health. Details: ${error.message}`);
+      reject(`An error occurred while verifying the binary health. Details: ${error.message}`);
     });
   });
 };


### PR DESCRIPTION
This PR bumps workflow actions to their latest versions, thus avoiding deprecation warnings.
It also fixes a few typos on the way.